### PR TITLE
Make radioset value assume the value of selected radio

### DIFF
--- a/lib/widgets/radiobutton.js
+++ b/lib/widgets/radiobutton.js
@@ -26,6 +26,8 @@ function RadioButton(options) {
 
   Checkbox.call(this, options);
 
+  this.value = options.value || false;
+
   this.on('check', function() {
     var el = self;
     while (el = el.parent) {
@@ -39,6 +41,9 @@ function RadioButton(options) {
       }
       el.uncheck();
     });
+
+    this.value = options.value || true;
+
     this.emit('input');
   });
 }

--- a/lib/widgets/radioset.js
+++ b/lib/widgets/radioset.js
@@ -25,6 +25,17 @@ function RadioSet(options) {
   Box.call(this, options);
 }
 
+Object.defineProperty(RadioSet.prototype, "value", {
+  get: function value() {
+    for (child of this.children) {
+      if (child.type === 'radio-button') {
+        if (child.checked)
+          return child.value;
+      }
+    }
+  },
+});
+
 RadioSet.prototype.__proto__ = Box.prototype;
 
 RadioSet.prototype.type = 'radio-set';


### PR DESCRIPTION
- Made a radiobutton assume proper value instead of true/false.
  Just like in html where every <input type="radio"> can have a proper
  value
- Made radioset assume the value of selected radio. This makes easier to
  handle the radioset value once the form is submitted, since in the
  submitted data we can now access the selected value using
  `submittedData.radio-set`, which is easier than checking which index
  of `submittedData.radiobutton` is set to true. This is specially
  useful when the radio buttons are constructed dynamically instead of
  being hard-coded.