### PR TITLE
log: fix scrollback line limit

### DIFF
--- a/src/lib/widgets/log.js
+++ b/src/lib/widgets/log.js
@@ -60,7 +60,7 @@ Log.prototype.add = function() {
   this.emit('log', text);
   var ret = this.pushLine(text);
   if (this._clines.fake.length > this.scrollback) {
-    this.shiftLine(0, (this.scrollback / 3) | 0);
+    this.shiftLine(Math.max(this._clines.fake.length - this.scrollback, this.scrollback / 3) | 0);
   }
   return ret;
 };


### PR DESCRIPTION
There are two issues with the scrollback limit of the Log component.

1. shiftLine is used incorrectly (two arguments instead of one), so only a single line is removed from the scrollback on each call.
2. If the caller pushes a huge number of lines on each call, the log can still exceed the scrollback limit.

Issue 1 can be reproduced by any code that repeatedly calls log with a string containing a newline, issue 2 is more theoretical, but this commit fixes both at the same time.