### PR TITLE
fix: using scroll wheel or CTRL + U listtable properly selects row 1

### DIFF
--- a/src/lib/widgets/listtable.js
+++ b/src/lib/widgets/listtable.js
@@ -176,7 +176,7 @@ ListTable.prototype.setData = function(rows) {
 
 ListTable.prototype._select = ListTable.prototype.select;
 ListTable.prototype.select = function(i) {
-  if (i === 0) {
+  if (i <= 0) {
     i = 1;
   }
   if (i <= this.childBase) {


### PR DESCRIPTION
Using a list table element and navigating in the list with CTRL + U or using the scroll wheel it would select the header row. This is because it was only properly trapping against row 0 if it was set to exactly row 0. Simply changing the check to look at <= 0 fixes this so regardless of navigation method you can never select less than row 1 on a list table.