### PR TITLE
feat: add censorChar option when using censored text

### DIFF
--- a/src/lib/widgets/textbox.js
+++ b/src/lib/widgets/textbox.js
@@ -28,6 +28,7 @@ function Textbox(options) {
 
   this.secret = options.secret;
   this.censor = options.censor;
+  this.censorChar = options.censorChar || "*";
 }
 
 Textbox.prototype.__proto__ = Textarea.prototype;
@@ -55,7 +56,7 @@ Textbox.prototype.setValue = function(value) {
     if (this.secret) {
       this.setContent('');
     } else if (this.censor) {
-      this.setContent(Array(this.value.length + 1).join('*'));
+      this.setContent(Array(this.value.length + 1).join(this.censorChar));
     } else {
       visible = -(this.width - this.iwidth - 1);
       val = this.value.replace(/\t/g, this.screen.tabc);


### PR DESCRIPTION
This adds the ability to specify the character used for the censor option called censorChar. An example would be...

```
   const input = blessed.textbox({
    inputOnFocus: true,
    censor: true,
    censorChar: "•",
  });
```
I chose to go with another option rather than have the censor property play double duty as it makes the data types clear.